### PR TITLE
Using addSpotify instead of addSpotifyQueue

### DIFF
--- a/index.js
+++ b/index.js
@@ -902,7 +902,7 @@ function _vote(text, channel, userName) {
                             slack.sendMessage("Valid vote by " + userName + "!", channel.id)
                             votedTimes++
                         }
-                        if(votedTimes >= voteVictory)
+                        if(listOfVotes.length >= voteVictory)
                         {
                             slack.sendMessage("Vote passed! Will put " + trackName + " on top! Will reset votes for this track.", channel.id)
                             delete votes[trackName]

--- a/index.js
+++ b/index.js
@@ -766,9 +766,9 @@ function _add(input, channel) {
                             //Then add the track to playlist...
 
                             // Old version..  New is supposed to fix 500 problem...
-                            sonos.addSpotifyQueue(spid, function (err, res) {
+                            //sonos.addSpotifyQueue(spid, function (err, res) {
 
-                            // sonos.addSpotify(spid, function (err, res) {
+                            sonos.addSpotify(spid, function (err, res) {
                                 var message = '';
                                 if(res) {
                                     var queueLength = res[0].FirstTrackNumberEnqueued;


### PR DESCRIPTION
Pulled the update that fixes the new token requirements, but it looks like the old addSpotifyQueue function was uncommented. I recommented that and uncommented addSpotify, which works for me. 