### PR TITLE
Switch to semver released versions of Sonos

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,12 +30,12 @@
   "license": "ISC",
   "dependencies": {
     "@slack/client": "^3.5.1",
+    "html-entities": "^1.2.0",
     "htmlencode": "0.0.4",
     "nconf": "^0.8.4",
-    "sonos": "git+https://github.com/bencevans/node-sonos.git#master",
+    "sonos": "^0.22.1",
     "urlencode": "^1.1.0",
-    "urllib-sync": "^1.1.2",
-    "html-entities": "^1.2.0"
+    "urllib-sync": "^1.1.2"
   },
   "engines": {
     "node": ">=6.0.0"


### PR DESCRIPTION
It's looking likely that the export signature from node-sonos will change in the near future. Switching to lock to a released version will stop zenmusic from breaking when the changes land in node-sonos master.

P.S. We'd love to have zenmusic on the node-sonos [In The Wild](https://github.com/bencevans/node-sonos#in-the-wild) list. Feel free to send a PR in :sparkles: 